### PR TITLE
fix: don't try to run xattr on linux

### DIFF
--- a/format/repositories.bzl
+++ b/format/repositories.bzl
@@ -47,7 +47,7 @@ def rules_format_dependencies():
         sha256 = "978eaffdc3716bbc0859aecee0d83875cf3ab8d8725779448f0035309d9ad9f3",
         url = "https://github.com/nicklockwood/SwiftFormat/releases/download/0.49.17/swiftformat.zip",
         patch_cmds = [
-            "xattr -c swiftformat",
+            "if command -v xattr > /dev/null; then xattr -c swiftformat; fi",
             "chmod u+x swiftformat",
         ],
         build_file_content = "filegroup(name = \"swiftformat_mac\", srcs=[\"swiftformat\"], visibility=[\"//visibility:public\"])",


### PR DESCRIPTION
The proper fix would be a toolchain that only fetches swiftformat for the host platform.