### PR TITLE
chore: remove yaml from prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Supported languages:
 | ✓         | Java                      | [google-java-format]                                           |
 | ✓         | JavaScript/TypeScript/TSX | [Prettier]                                                     |
 | ✓         | CSS/HTML                  | [Prettier]                                                     |
-| ✓         | JSON/YAML                 | [Prettier]                                                     |
+| ✓         | JSON                      | [Prettier]                                                     |
 | ✓         | Markdown                  | [Prettier]                                                     |
 | ✓         | Bash                      | [prettier-plugin-sh](https://github.com/un-ts/prettier)        |
 | ✓         | Starlark (Bazel)          | [Buildifier](https://github.com/keith/buildifier-prebuilt)     |
@@ -26,6 +26,7 @@ Supported languages:
 |           | Go                        | [gofmt](https://pkg.go.dev/cmd/gofmt)                          |
 |           | C/C++/C#                  | clang-format                                                   |
 |           | Rust                      | [rustfmt](https://github.com/rust-lang/rustfmt)                |
+|           | YAML                      | [yamlfmt](https://github.com/google/yamlfmt)                   |
 
 More languages TODO: https://github.com/aspect-build/bazel-super-formatter/issues/6
 

--- a/format/format.sh
+++ b/format/format.sh
@@ -79,9 +79,9 @@ if [ -n "$files" ] && [ -n "$bin" ]; then
 fi
 
 if [ "$#" -eq 0 ]; then
-  files=$(git ls-files '*.js' '*.sh' '*.ts' '*.tsx' '*.json' '*.css' '*.html' '*.md' '*.yaml' '*.yml')
+  files=$(git ls-files '*.js' '*.sh' '*.ts' '*.tsx' '*.json' '*.css' '*.html' '*.md')
 else
-  files=$(find "$@" -name '*.js' -or -name '*.sh' -or -name '*.ts' -or -name '*.tsx' -or -name '*.json' -or -name '*.css' -or -name '*.html' -or -name '*.md' -or -name '*.yaml' -or -name '*.yml')
+  files=$(find "$@" -name '*.js' -or -name '*.sh' -or -name '*.ts' -or -name '*.tsx' -or -name '*.json' -or -name '*.css' -or -name '*.html' -or -name '*.md')
 fi
 bin=$(rlocation aspect_rules_format/format/prettier.sh)
 if [ -n "$files" ] && [ -n "$bin" ]; then


### PR DESCRIPTION
It is causing Node.js to crash in our big repo that uses this. Also per #2 we should wire this up with a different tool