### PR TITLE
switch language configs to opt-in

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@aspect_bazel_lib//lib:run_binary.bzl", "run_binary")
 load("@aspect_rules_format_npm//:defs.bzl", "npm_link_all_packages")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
@@ -56,4 +57,57 @@ diff_test(
     failure_message = "Please run:  bazel run //:vendor_requirements",
     file1 = "requirements.bzl",
     file2 = ":make_platform_agnostic",
+)
+
+###############################################################
+# Check that our documentation includes all the language flags.
+# Each flag looks like this:
+bazelrc_line = "run --@aspect_rules_format//format:{}_enabled=true"
+
+# A little python program to format the LANGS constant into markdown content
+write_file(
+    name = "converter",
+    out = "convert_langs.py",
+    content = [
+        "#!/usr/bin/env python3",
+        "import sys",
+        "with open('format/langs.bzl') as bzl:",
+        "  starlark = bzl.read()",
+        # starlark is a python subset so we can just execute it for side-effects
+        "with open(sys.argv[1], 'w') as out:",
+        "  exec(starlark)",
+        "  [out.write('%s\\n'.format(lang)) for lang in LANGS]" % bazelrc_line,
+    ],
+)
+
+py_binary(
+    name = "convert_langs",
+    srcs = ["convert_langs.py"],
+)
+
+run_binary(
+    name = "extract_langs",
+    srcs = ["//format:langs.bzl"],
+    outs = ["expected"],
+    args = ["$(execpath expected)"],
+    tool = "convert_langs",
+)
+
+# Cheap awk one-liner to read the actual documentation block out of the markdown
+genrule(
+    name = "actual",
+    srcs = ["README.md"],
+    outs = ["README.lang_flags"],
+    # Print lines between PAT1 and PAT2 - not including PAT1 and PAT2
+    # https://stackoverflow.com/questions/38972736/how-to-print-lines-between-two-patterns-inclusive-or-exclusive-in-sed-awk-or
+    cmd = "awk '/{PAT1}/{{flag=1; next}} /{PAT2}/{{flag=0}} flag' $< >$@".format(
+        PAT1 = "Enable fetching formatter toolchains",
+        PAT2 = "```",
+    ),
+)
+
+diff_test(
+    name = "test_enable_flag_doc",
+    file1 = "expected",
+    file2 = "actual",
 )

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This will exit non-zero if formatting is needed. You would typically run the che
 
 ## Configuration
 
-### Enable a formatter for your language
+### Enable the formatters for your languages
 
 When you enable a language, it causes the super-formatter to fetch additional tooling as a
 runtime dependency of the format binary.
@@ -103,9 +103,9 @@ Add some of these lines to `.bazelrc`:
 ```
 # Enable fetching formatter toolchains
 run --@aspect_rules_format//format:java_enabled=true
+run --@aspect_rules_format//format:proto_enabled=true
 run --@aspect_rules_format//format:python_enabled=true
 run --@aspect_rules_format//format:swift_enabled=true
-run --@aspect_rules_format//format:proto_enabled=true
 run --@aspect_rules_format//format:terraform_enabled=true
 ```
 

--- a/README.md
+++ b/README.md
@@ -93,19 +93,20 @@ This will exit non-zero if formatting is needed. You would typically run the che
 
 ## Configuration
 
-### Disable a formatter for unused language
+### Enable a formatter for your language
 
-If you don't use a language in your whole repo, you can turn off fetching the tooling.
+When you enable a language, it causes the super-formatter to fetch additional tooling as a
+runtime dependency of the format binary.
 
 Add some of these lines to `.bazelrc`:
 
 ```
-# Avoid fetching unneeded formatting toolchains
-run --@aspect_rules_format//format:java_enabled=false
-run --@aspect_rules_format//format:python_enabled=false
-run --@aspect_rules_format//format:swift_enabled=false
-run --@aspect_rules_format//format:proto_enabled=false
-run --@aspect_rules_format//format:terraform_enabled=false
+# Enable fetching formatter toolchains
+run --@aspect_rules_format//format:java_enabled=true
+run --@aspect_rules_format//format:python_enabled=true
+run --@aspect_rules_format//format:swift_enabled=true
+run --@aspect_rules_format//format:proto_enabled=true
+run --@aspect_rules_format//format:terraform_enabled=true
 ```
 
 ### Changing the version of a formatter tool

--- a/e2e/workspace/.bazelrc
+++ b/e2e/workspace/.bazelrc
@@ -1,3 +1,0 @@
-build --@aspect_rules_format//format:java_enabled=false
-build --@aspect_rules_format//format:swift_enabled=false
-build --@aspect_rules_format//format:python_enabled=false

--- a/format/BUILD.bazel
+++ b/format/BUILD.bazel
@@ -73,7 +73,7 @@ alias(
 [
     bool_flag(
         name = s + "_enabled",
-        build_setting_default = True,
+        build_setting_default = False,
     )
     for s in LANGS
 ]

--- a/format/BUILD.bazel
+++ b/format/BUILD.bazel
@@ -3,6 +3,8 @@ load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@aspect_rules_format_npm//:prettier/package_json.bzl", prettier = "bin")
 load(":langs.bzl", "LANGS")
 
+exports_files(["langs.bzl"])
+
 bzl_library(
     name = "repositories",
     srcs = ["repositories.bzl"],

--- a/format/langs.bzl
+++ b/format/langs.bzl
@@ -1,3 +1,3 @@
-# These are the ones users can disable.
+# These are the ones users can enable.
 # We always do Prettier since it does so many languages.
 LANGS = ["java", "swift", "python", "proto", "terraform"]

--- a/format/langs.bzl
+++ b/format/langs.bzl
@@ -1,3 +1,6 @@
+"Constants for language-specific configuration"
+
 # These are the ones users can enable.
 # We always do Prettier since it does so many languages.
-LANGS = ["java", "swift", "python", "proto", "terraform"]
+# keep sorted
+LANGS = ["java", "proto", "python", "swift", "terraform"]


### PR DESCRIPTION
This will scale better as we add more languages to the formatter, so we don't slow down pre-commit in a way users don't easily discover how to override

BREAKING CHANGE:
Users must check their .bazelrc to include languages they use, or else these will be silently dropped.