### PR TITLE
fix: List Go as a language too

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Add some of these lines to `.bazelrc`:
 
 ```
 # Enable fetching formatter toolchains
+run --@aspect_rules_format//format:go_enabled
 run --@aspect_rules_format//format:java_enabled
 run --@aspect_rules_format//format:proto_enabled
 run --@aspect_rules_format//format:python_enabled

--- a/format/BUILD.bazel
+++ b/format/BUILD.bazel
@@ -96,10 +96,12 @@ sh_binary(
     data = [
         ":buildifier",
         ":prettier",
-        # We can't make this optional, because it's an eager fetch as soon as this
-        # label appears anywhere in this file.
-        "@go_sdk//:bin/gofmt",
     ] + select(
+        {
+            ":format_go": ["@go_sdk//:bin/gofmt"],
+            "//conditions:default": [],
+        },
+    ) + select(
         {
             ":format_java": [":java-format"],
             "//conditions:default": [],

--- a/format/langs.bzl
+++ b/format/langs.bzl
@@ -3,4 +3,4 @@
 # These are the ones users can enable.
 # We always do Prettier since it does so many languages.
 # keep sorted
-LANGS = ["java", "proto", "python", "swift", "terraform"]
+LANGS = ["go", "java", "proto", "python", "swift", "terraform"]


### PR DESCRIPTION
Now that users opt-in to the languages they use, it's confusing that Go isn't included in the list.