### PR TITLE
fix: warning when formatting specific files

### DIFF
--- a/format/format.sh
+++ b/format/format.sh
@@ -76,7 +76,7 @@ esac
 if [ "$#" -eq 0 ]; then
   files=$(git ls-files 'BUILD' '*/BUILD.bazel' '*.bzl' '*.BUILD' 'WORKSPACE' '*.bazel')
 else
-  files=$(find "$@" -name 'BUILD' -or -name '*/BUILD.bazel' -or -name '*.bzl' -or -name '*.BUILD' -or -name 'WORKSPACE' -or -name '*.bazel')
+  files=$(find "$@" -name 'BUILD' -or -name '*.bzl' -or -name '*.BUILD' -or -name 'WORKSPACE' -or -name '*.bazel')
 fi
 bin=$(rlocation buildifier_prebuilt/buildifier/buildifier)
 if [ -n "$files" ] && [ -n "$bin" ]; then


### PR DESCRIPTION
Fix the warning below when formatting specific build files, e.g. when running `bazel run @aspect_rules_format//format path/to/BUILD.bazel`.

```
find: warning: ‘-name’ matches against basenames only, but the given
pattern contains a directory separator (‘/’), thus the expression will
evaluate to false all the time.  Did you mean ‘-wholename’?
```

The warning comes from the `-name '*/BUILD.bazel'` argument to the `find` command, because it contains a `/` character. We can remove this argument, since it will always evaluate to false and `BUILD.bazel` files will be found by the `-name '*.bazel'` argument.