### PR TITLE
Update prettier, prettier-* to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "prettier": "*",
-    "prettier-plugin-sh": "*",
-    "prettier-plugin-sql": "*"
+    "prettier": "^2.8.7",
+    "prettier-plugin-sh": "^0.12.8",
+    "prettier-plugin-sql": "^0.14.0"
   },
   "pnpm": {
     "packageExtensions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,14 +3,14 @@ lockfileVersion: 5.4
 packageExtensionsChecksum: cd04f6dafd8727306c106c8a0b3c7263
 
 specifiers:
-  prettier: '*'
-  prettier-plugin-sh: '*'
-  prettier-plugin-sql: '*'
+  prettier: ^2.8.7
+  prettier-plugin-sh: ^0.12.8
+  prettier-plugin-sql: ^0.14.0
 
 dependencies:
-  prettier: 2.7.1_hzcjiwdmsijenev2d6a5cl465a
-  prettier-plugin-sh: 0.12.8_prettier@2.7.1
-  prettier-plugin-sql: 0.12.1_prettier@2.7.1
+  prettier: 2.8.7_whkmnyg4gs3djzcukwmxxipg5m
+  prettier-plugin-sh: 0.12.8_prettier@2.8.7
+  prettier-plugin-sql: 0.14.0_prettier@2.8.7
 
 packages:
 
@@ -20,10 +20,10 @@ packages:
     dependencies:
       cross-spawn: 7.0.3
       is-glob: 4.0.3
-      open: 8.4.0
+      open: 8.4.2
       picocolors: 1.0.0
       tiny-glob: 0.2.9
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /argparse/2.0.1:
@@ -112,15 +112,15 @@ packages:
       randexp: 0.4.6
     dev: false
 
-  /node-sql-parser/4.5.1:
-    resolution: {integrity: sha512-99/6q5CTRjYNcCPq2waae4yJZ//T0XBjEDCurGK93ViuSgN4txsp1LqGHxQlg0SpOR1xJUNLKSF9UbZibSnE5w==}
+  /node-sql-parser/4.6.6:
+    resolution: {integrity: sha512-zpash5xnRY6+0C9HFru32iRJV1LTkwtrVpO90i385tYVF6efyXK/B3Nsq/15Fuv2utxrqHNjKtL55OHb8sl+eQ==}
     engines: {node: '>=8'}
     dependencies:
       big-integer: 1.6.51
     dev: false
 
-  /open/8.4.0:
-    resolution: {integrity: sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==}
+  /open/8.4.2:
+    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
     dependencies:
       define-lazy-prop: 2.0.0
@@ -137,40 +137,40 @@ packages:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
     dev: false
 
-  /prettier-plugin-sh/0.12.8_prettier@2.7.1:
+  /prettier-plugin-sh/0.12.8_prettier@2.8.7:
     resolution: {integrity: sha512-VOq8h2Gn5UzrCIKm4p/nAScXJbN09HdyFDknAcxt6Qu/tv/juu9bahxSrcnM9XWYA+Spz1F1ANJ4LhfwB7+Q1Q==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     peerDependencies:
       prettier: ^2.0.0
     dependencies:
       mvdan-sh: 0.10.1
-      prettier: 2.7.1_hzcjiwdmsijenev2d6a5cl465a
+      prettier: 2.8.7_whkmnyg4gs3djzcukwmxxipg5m
       sh-syntax: 0.3.7
-      synckit: 0.8.3
+      synckit: 0.8.5
     dev: false
 
-  /prettier-plugin-sql/0.12.1_prettier@2.7.1:
-    resolution: {integrity: sha512-2z0pMmQEC61Xywerw2FJFpEIaA9lJUjB5mj+9dfRU8HkU7iICFrIizpMjSSDMoGkhh5W+IRROVgLlgRdpphI7g==}
+  /prettier-plugin-sql/0.14.0_prettier@2.8.7:
+    resolution: {integrity: sha512-dRgINgNd3ZhBDuO/+EFalJjSlAqNXvXv9XDtSCeMufXaP6O64HHLBo1Szo+l+cfvXFxwvkTSGrS+sjpEpSchNA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     peerDependencies:
       prettier: ^2.0.0
     dependencies:
-      node-sql-parser: 4.5.1
-      prettier: 2.7.1_hzcjiwdmsijenev2d6a5cl465a
-      sql-formatter: 10.7.2
-      tslib: 2.4.0
+      node-sql-parser: 4.6.6
+      prettier: 2.8.7_whkmnyg4gs3djzcukwmxxipg5m
+      sql-formatter: 12.2.0
+      tslib: 2.5.0
     dev: false
 
-  /prettier/2.7.1_hzcjiwdmsijenev2d6a5cl465a:
-    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
+  /prettier/2.8.7_whkmnyg4gs3djzcukwmxxipg5m:
+    resolution: {integrity: sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
       prettier-plugin-sh: '*'
       prettier-plugin-sql: '*'
     dependencies:
-      prettier-plugin-sh: 0.12.8_prettier@2.7.1
-      prettier-plugin-sql: 0.12.1_prettier@2.7.1
+      prettier-plugin-sh: 0.12.8_prettier@2.8.7
+      prettier-plugin-sql: 0.14.0_prettier@2.8.7
     dev: false
 
   /railroad-diagrams/1.0.0:
@@ -194,7 +194,7 @@ packages:
     resolution: {integrity: sha512-xIB/uRniZ9urxAuXp1Ouh/BKSI1VK8RSqfwGj7cV57HvGrFo3vHdJfv8Tdp/cVcxJgXQTkmHr5mG5rqJW8r4wQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     dependencies:
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /shebang-command/2.0.0:
@@ -209,20 +209,20 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /sql-formatter/10.7.2:
-    resolution: {integrity: sha512-YspJXMr2rKMGZY50zYRBs2nCtEO/AKDrmQOxmV2CrGEOFSXUhY3YbsOUe6lX0T/7xbBs4pAYv4UObmwf78vtKg==}
+  /sql-formatter/12.2.0:
+    resolution: {integrity: sha512-wNsPUdOD6nnN9RUgHlNprQtm+iLW5LTOy/T0/2DDr2UeWSP8mvlQHrx6TY+IG1nfu5Kipq9GaOtS9SVq8s0Vig==}
     hasBin: true
     dependencies:
       argparse: 2.0.1
       nearley: 2.20.1
     dev: false
 
-  /synckit/0.8.3:
-    resolution: {integrity: sha512-1goXnDYNJlKwCM37f5MTzRwo+8SqutgVtg2d37D6YnHHT4E3IhQMRfKiGdfTZU7LBlI6T8inCQUxnMBFHrbqWw==}
+  /synckit/0.8.5:
+    resolution: {integrity: sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==}
     engines: {node: ^14.18.0 || >=16.0.0}
     dependencies:
       '@pkgr/utils': 2.3.1
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /tiny-glob/0.2.9:
@@ -232,8 +232,8 @@ packages:
       globrex: 0.1.2
     dev: false
 
-  /tslib/2.4.0:
-    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+  /tslib/2.5.0:
+    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
     dev: false
 
   /which/2.0.2:


### PR DESCRIPTION
2.7.X release of prettier can fail with
`Unknown TypeScript node type: "TSSatisfiesExpression"`

Which is fixed by the 2.8.X, see
https://prettier.io/blog/2022/11/23/2.8.0.html

Please include a summary of your changes and link to the related issue(s).
Please also include relevant motivation and context.

You may delete parts of the template if they are obvious to all possible reviewers, e.g. the information is in the one-line description.

**Type of change**

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature or functionality (change which adds functionality)
- [ ] Style (white-space, formatting, etc...)
- [ ] Refactor (a code change that neither fixes a bug or adds a new feature)
- [ ] Performance (a code change that improves performance)
- [ ] Documentation (updates to documentation or READMEs)
- [x] Chore (any other change that doesn't affect source or test files)

**For changes visible to end-users**

- [ ] Breaking change (this change will force users to change their own code or config)
- [ ] Relevant documentation has been updated
- [x] Suggested release notes are provided below:

Upgrade to Prettier 2.8.x which adds support for TypeScript 4.9 satisfies operator. 

**Test plan**

How has this been tested?

- [x] Covered by existing test cases
- [ ] New test cases added
- [ ] Manual testing

If part of the test plan included manual testing, please provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
